### PR TITLE
Remove redundant headers and the default gray background behind Discover Nooks Feed cards.

### DIFF
--- a/app/assets/stylesheets/components/_nooks_cards.scss
+++ b/app/assets/stylesheets/components/_nooks_cards.scss
@@ -1,3 +1,7 @@
+.nooks-container {
+  background-color: $primary-background;
+}
+
 .nook-card {
     background-color: rgba(255, 255, 255, 0.9); /* Transparent with a light white color */
     border: 1px solid #ccc;
@@ -8,14 +12,14 @@
     font-size: 16px;
     color: black; /* Font color is black */
   }
-  
+
   /* Media query for iPhone 12 or similar screen size */
   @media (max-width: 375px) {
     .nook-card {
       padding: 10px;
       font-size: 14px;
     }
-  }  
+  }
 
   .nook-card .swiper {
     width: 150px; /* Adjust the width of the picture square as needed */

--- a/app/views/pages/_footnotes_dashboard.html.erb
+++ b/app/views/pages/_footnotes_dashboard.html.erb
@@ -1,5 +1,3 @@
-<h2>New Footnotes on your NookBooks</h2>
-
 <!-- Which one of these is meant to stay? Sorry, can't tell first from last, so kept them all:
 
 <div class="container all-footnotes mt-5 mb-5">
@@ -33,6 +31,3 @@
   <% end %>
     </div>
 </div> -->
-      
-
-

--- a/app/views/pages/_footnotes_feed.html.erb
+++ b/app/views/pages/_footnotes_feed.html.erb
@@ -1,5 +1,3 @@
-<h2>Most Recently Added Footnotes</h2>
-
 <div class="all-footnotes">
   <% @recently_added_footnotes.each do |footnote| %>
     <div class="footnote">

--- a/app/views/pages/_nooks_feed.html.erb
+++ b/app/views/pages/_nooks_feed.html.erb
@@ -1,4 +1,3 @@
-<h2>Most Recently Added Nooks</h2>
 <div class="nooks-container">
   <% recently_added_nooks.each do |nook| %>
     <div class="nook-card">


### PR DESCRIPTION
The headings that were removed:

<h2>Most Recently Added Nooks</h2>
<h2>Most Recently Added Footnotes</h2>
<h2>New Footnotes on your NookBooks</h2>

